### PR TITLE
Update install-local-agent.sh

### DIFF
--- a/moonbox-agent/moonbox-java-agent/bin/install-local-agent.sh
+++ b/moonbox-agent/moonbox-java-agent/bin/install-local-agent.sh
@@ -29,7 +29,9 @@ mkdir -p ${REPEATER_TARGET_DIR}/cfg
 cp -r ../cfg/ ${REPEATER_TARGET_DIR} \
     && cp ../moonbox-module/target/moonbox-module-*-jar-with-dependencies.jar ${REPEATER_TARGET_DIR}/ \
     && cp ../moonbox-plugins/*/*-plugin/target/*-jar-with-dependencies.jar ${REPEATER_TARGET_DIR}/plugins/ \
-    && cp -r ../bin/ ${REPEATER_TARGET_DIR}
+    && cp -r ../bin/ ${REPEATER_TARGET_DIR} \
+    && cp -r ../cfg/ ${REPEATER_TARGET_DIR}/cfg/
+
 
 # install repeater
 mkdir -p  ~/.sandbox-module/


### PR DESCRIPTION
在脚本中，少了个cfg文件夹中文件的拷贝动作。
进而导致使用install-local-agent.sh进行本地项目初始化后，本地项目加载agent的时候报repeater.properties找不到。 在脚本中增加copy，修复此问题。