### PR TITLE
okhttp回放时候bug修复

### DIFF
--- a/moonbox-agent/moonbox-java-agent/moonbox-plugins/moonbox/okhttp-plugin/src/main/java/com/vivo/jvm/sandbox/moonbox/plugin/okhttp/util/HttpOkUtil.java
+++ b/moonbox-agent/moonbox-java-agent/moonbox-plugins/moonbox/okhttp-plugin/src/main/java/com/vivo/jvm/sandbox/moonbox/plugin/okhttp/util/HttpOkUtil.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.reflect.MethodUtils;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.util.Objects;
 
 
 /**
@@ -55,7 +56,7 @@ public class HttpOkUtil {
             Object bodyByte = content.get(body);
             Object charset = MethodUtils.invokeMethod(MediaType, "charset");
 
-            return new String((byte[]) bodyByte, charset.toString());
+            return new String((byte[]) bodyByte, Objects.isNull(charset)?"UTF-8":charset.toString());
         } catch (Exception e) {
             MoonboxLogUtils.error("HttpOkRecordModifierHandler.getBody error:", e);
         }

--- a/moonbox-server/moonbox-service-console/src/main/java/com/vivo/internet/moonbox/service/console/util/HttpDataConvert.java
+++ b/moonbox-server/moonbox-service-console/src/main/java/com/vivo/internet/moonbox/service/console/util/HttpDataConvert.java
@@ -19,10 +19,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
+
 
 import org.apache.commons.lang3.StringUtils;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.TypeReference;
 import com.google.common.base.Splitter;
 import com.vivo.internet.moonbox.common.api.model.InvokeType;
@@ -51,7 +54,10 @@ public class HttpDataConvert {
         String requestMethod = (String) requestMap.get("requestMethod");
         Map<String, String> headers = getSubInvokeHttpHeaders(requestHeaders, invokeType);
         Object requestBody = requestMap.get("requestBody");
-        Object body = jsonStringToObj((String) requestBody);
+        Object body = null;
+        if (!Objects.isNull(requestBody)) {
+            body = JSONObject.parse(requestBody.toString());
+        }
         return HttpData.builder().body(body).headers(headers).paramsMap((Map) requestMap.get("requestParams"))
                 .method(requestMethod).build();
     }

--- a/moonbox-server/moonbox-service-console/src/main/java/com/vivo/internet/moonbox/service/console/util/RecordConvert.java
+++ b/moonbox-server/moonbox-service-console/src/main/java/com/vivo/internet/moonbox/service/console/util/RecordConvert.java
@@ -140,7 +140,7 @@ public class RecordConvert {
             // 转换apache http 和ok http两种子调用http类型
             invocationVo = new HttpInvocationVo();
             HttpDataConvert.HttpData httpData = HttpDataConvert.convert(requestObjs, invokeType);
-            ((HttpInvocationVo) invocationVo).setBody(httpData);
+            ((HttpInvocationVo) invocationVo).setBody(httpData.getBody());
             ((HttpInvocationVo) invocationVo).setHeaders(httpData.getHeaders());
             ((HttpInvocationVo) invocationVo).setParamsMap(httpData.getParamsMap());
             ((HttpInvocationVo) invocationVo).setMethod(httpData.getMethod());


### PR DESCRIPTION
修复的bug内容如下：
1. okhttp请求时候，如果charset为空的空指针异常。
2. 子调用中有okhttp请求时，请求的body为list数组格式，在控制台中报json转换错误异常。
3. 子调用中有okhttp请求时，在子调用详情界面，body的模块包含请求header头等内容。