### PR TITLE
解决录制记录中的uri未encode，导致页面查询录制数据分页列表时响应码400的问题

### DIFF
--- a/client/src/views/record/index.vue
+++ b/client/src/views/record/index.vue
@@ -529,7 +529,7 @@ export default {
         pageSize: this.recordForm.pageSize4,
         taskRunId: row.taskRunId || taskRunId,
         traceIdCondition: this.recordForm.traceIdCondition,
-        uri: row.recordUri
+        uri: encodeURIComponent(row.recordUri)
       }
       this.loading = true
       API.record.getUriTaskDataList(params).then((res) => {

--- a/moonbox-server/moonbox-service-console/src/main/java/com/vivo/internet/moonbox/service/console/impl/ConsoleDataServiceImpl.java
+++ b/moonbox-server/moonbox-service-console/src/main/java/com/vivo/internet/moonbox/service/console/impl/ConsoleDataServiceImpl.java
@@ -15,6 +15,7 @@ limitations under the License.
  */
 package com.vivo.internet.moonbox.service.console.impl;
 
+import java.net.URLDecoder;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -70,7 +71,7 @@ public class ConsoleDataServiceImpl implements ConsoleRecordDataService {
         pageRequest.setPageSize(dataListRequest.getPageSize());
         pageRequest.setPageNum(dataListRequest.getPageNum());
 
-        RecordDataListQuery listQuery = RecordDataListQuery.builder().recordUri(dataListRequest.getUri())
+        RecordDataListQuery listQuery = RecordDataListQuery.builder().recordUri(URLDecoder.decode(dataListRequest.getUri()))
                 .startTime(dataListRequest.getStartTime()).traceId(dataListRequest.getTraceIdCondition())
                 .endTime(dataListRequest.getEndTime()).recordTaskRunId(dataListRequest.getTaskRunId()).build();
         pageRequest.setQueryParam(listQuery);

--- a/moonbox-server/moonbox-service-console/src/main/java/com/vivo/internet/moonbox/service/console/impl/ConsoleDataServiceImpl.java
+++ b/moonbox-server/moonbox-service-console/src/main/java/com/vivo/internet/moonbox/service/console/impl/ConsoleDataServiceImpl.java
@@ -71,7 +71,7 @@ public class ConsoleDataServiceImpl implements ConsoleRecordDataService {
         pageRequest.setPageSize(dataListRequest.getPageSize());
         pageRequest.setPageNum(dataListRequest.getPageNum());
 
-        RecordDataListQuery listQuery = RecordDataListQuery.builder().recordUri(URLDecoder.decode(dataListRequest.getUri()))
+        RecordDataListQuery listQuery = RecordDataListQuery.builder().recordUri(dataListRequest.getUri() != null ? URLDecoder.decode(dataListRequest.getUri()) : null)
                 .startTime(dataListRequest.getStartTime()).traceId(dataListRequest.getTraceIdCondition())
                 .endTime(dataListRequest.getEndTime()).recordTaskRunId(dataListRequest.getTaskRunId()).build();
         pageRequest.setQueryParam(listQuery);


### PR DESCRIPTION
## Description
解决录制记录中的uri未encode，导致页面查询录制数据分页列表时响应码400的问题

## Link to issue
<!-- There should be an issue before you submit this PR -->
Ref issue #42

## Screenshots
<!-- Please add screenshots if need -->

## Testing
<!-- How to test PR -->

