### PR TITLE
对hbase-plugin和tars-plugin包的parent进行修改，暂时避免mvn install的报错

### DIFF
--- a/moonbox-agent/moonbox-java-agent/moonbox-plugins/moonbox/hbase-plugin/pom.xml
+++ b/moonbox-agent/moonbox-java-agent/moonbox-plugins/moonbox/hbase-plugin/pom.xml
@@ -3,9 +3,10 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>repeater-plugins</artifactId>
-        <groupId>com.vivo.jvm.sandbox</groupId>
+        <artifactId>moonbox-plugins</artifactId>
+        <groupId>com.vivo.internet</groupId>
         <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <dependencies>
         <dependency>

--- a/moonbox-agent/moonbox-java-agent/moonbox-plugins/moonbox/tars-plugin/pom.xml
+++ b/moonbox-agent/moonbox-java-agent/moonbox-plugins/moonbox/tars-plugin/pom.xml
@@ -3,9 +3,10 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>repeater-plugins</artifactId>
-        <groupId>com.vivo.jvm.sandbox</groupId>
+        <artifactId>moonbox-plugins</artifactId>
+        <groupId>com.vivo.internet</groupId>
         <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
fix: 根据[issue链接](https://github.com/vivo/MoonBox/issues/71)，对hbase-plugin和tars-plugin包的parent进行修改，暂时避免mvn install的报错

